### PR TITLE
Adjust Next.js build check settings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary
- disable `ignoreDuringBuilds` for eslint
- disable `ignoreBuildErrors` for TypeScript

## Testing
- `npm run lint` *(fails: next not found)*
- `pnpm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d5dcb598083329743ebefe2dc26ce