### PR TITLE
Add basic page tests

### DIFF
--- a/app/articulado/page.test.tsx
+++ b/app/articulado/page.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ArticuladoPage from './page'
+
+describe('ArticuladoPage', () => {
+  it('filters lines based on search input', async () => {
+    render(<ArticuladoPage />)
+    const input = screen.getByPlaceholderText(
+      'Pesquisar por descrição, código ou família...'
+    )
+    await userEvent.type(input, 'Tubos')
+    expect(
+      screen.getByText('Tubagem em PVC para instalações elétricas')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Quadro elétrico principal QGBT')).toBeNull()
+  })
+})

--- a/app/rfqs/page.test.tsx
+++ b/app/rfqs/page.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RFQsPage from './page'
+
+describe('RFQsPage', () => {
+  it('filters RFQs based on search input', async () => {
+    render(<RFQsPage />)
+    const input = screen.getByPlaceholderText('Pesquisar RFQs...')
+    await userEvent.type(input, 'Nortécnica')
+    expect(screen.getByText('RFQ-004')).toBeInTheDocument()
+    expect(screen.queryByText('RFQ-001')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add simple unit tests for articulado and rfqs pages

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d620894388332b1a65515dca9e453