### PR TITLE
Add awards API with conflict detection

### DIFF
--- a/app/api/adjudicacoes/route.ts
+++ b/app/api/adjudicacoes/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+import { Award } from '@/types/procurement'
+
+const DATA_PATH = path.join(process.cwd(), 'data', 'awards.json')
+
+async function readData(): Promise<Award[]> {
+  try {
+    const data = await fs.readFile(DATA_PATH, 'utf8')
+    return JSON.parse(data)
+  } catch {
+    return []
+  }
+}
+
+async function writeData(data: Award[]) {
+  await fs.mkdir(path.dirname(DATA_PATH), { recursive: true })
+  await fs.writeFile(DATA_PATH, JSON.stringify(data, null, 2))
+}
+
+export async function GET() {
+  const awards = await readData()
+  return NextResponse.json(awards)
+}
+
+export async function POST(req: NextRequest) {
+  const newAward: Award = await req.json()
+  const awards = await readData()
+
+  // conflict detection: check if any line articulado already awarded
+  for (const line of newAward.lines) {
+    if (awards.some(a => a.lines.some(l => l.articuladoId === line.articuladoId))) {
+      return NextResponse.json({ error: 'Line already awarded' }, { status: 409 })
+    }
+  }
+
+  awards.push(newAward)
+  await writeData(awards)
+  return NextResponse.json(newAward, { status: 201 })
+}

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS awards (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  award_date DATE NOT NULL,
+  total_value REAL NOT NULL,
+  status TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS award_lines (
+  id TEXT PRIMARY KEY,
+  award_id TEXT NOT NULL REFERENCES awards(id) ON DELETE CASCADE,
+  articulado_id TEXT NOT NULL,
+  supplier TEXT NOT NULL,
+  response_item_id TEXT,
+  quantity INTEGER NOT NULL,
+  unit_price REAL NOT NULL,
+  total_price REAL NOT NULL,
+  UNIQUE(articulado_id, supplier)
+);


### PR DESCRIPTION
## Summary
- define `awards` and `award_lines` tables in `schema.sql`
- create API routes under `app/api/adjudicacoes/` to save and list awards
- fetch existing awards and check conflicts when creating awards
- send created awards to the new API from the comparativo page

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6204ef2083329514a7116b6be635