### PR TITLE
Add audit logging

### DIFF
--- a/app/api/awards/create/route.ts
+++ b/app/api/awards/create/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { logAction } from '@/lib/audit'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  logAction(body.user ?? 'unknown', 'AWARD_CREATED', JSON.stringify(body))
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/responses/receive/route.ts
+++ b/app/api/responses/receive/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { logAction } from '@/lib/audit'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  logAction(body.user ?? 'unknown', 'RESPONSE_RECEIVED', JSON.stringify(body))
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/rfqs/send/route.ts
+++ b/app/api/rfqs/send/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { logAction } from '@/lib/audit'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  logAction(body.user ?? 'unknown', 'RFQ_SENT', JSON.stringify(body))
+  return NextResponse.json({ ok: true })
+}

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { getLogs } from '@/lib/audit'
+
+export default function LogsPage() {
+  const logs = getLogs()
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">Logs</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Histórico de Ações</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Timestamp</TableHead>
+                <TableHead>Utilizador</TableHead>
+                <TableHead>Ação</TableHead>
+                <TableHead>Detalhes</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {logs.map((log, idx) => (
+                <TableRow key={idx}>
+                  <TableCell>{new Date(log.timestamp).toLocaleString()}</TableCell>
+                  <TableCell>{log.user}</TableCell>
+                  <TableCell>{log.action}</TableCell>
+                  <TableCell className="whitespace-pre-wrap">{log.details}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -29,6 +29,7 @@ const navigation = [
   { name: "RFQs", href: "/rfqs", icon: ShoppingCart },
   { name: "Fornecedores", href: "/suppliers", icon: Users },
   { name: "Análise", href: "/analytics", icon: TrendingUp },
+  { name: "Logs", href: "/logs", icon: FileText },
   { name: "Configurações", href: "/settings", icon: Settings },
 ]
 

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -1,0 +1,36 @@
+import Database from 'better-sqlite3'
+import path from 'path'
+
+const db = new Database(path.join(process.cwd(), 'logs.db'))
+
+// Ensure Logs table exists
+const init = db.prepare(
+  `CREATE TABLE IF NOT EXISTS Logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    user TEXT NOT NULL,
+    action TEXT NOT NULL,
+    details TEXT NOT NULL
+  )`
+)
+init.run()
+
+export function logAction(user: string, action: string, details: string) {
+  const timestamp = new Date().toISOString()
+  db.prepare(
+    'INSERT INTO Logs (timestamp, user, action, details) VALUES (?,?,?,?)'
+  ).run(timestamp, user, action, details)
+}
+
+export interface LogEntry {
+  timestamp: string
+  user: string
+  action: string
+  details: string
+}
+
+export function getLogs(): LogEntry[] {
+  return db
+    .prepare('SELECT timestamp, user, action, details FROM Logs ORDER BY id DESC')
+    .all()
+}


### PR DESCRIPTION
## Summary
- log activity to a sqlite table with a new audit utility
- add API handlers for RFQ sending, response receiving and award creation that record logs
- list logged actions in a new Logs page
- expose Logs page in the sidebar navigation

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d62060bb88332b9da13ebcc9b9597