### PR TITLE
Handle database errors

### DIFF
--- a/app/api/articulado/route.ts
+++ b/app/api/articulado/route.ts
@@ -10,7 +10,10 @@ export async function GET() {
     return NextResponse.json(result.recordset)
   } catch (err) {
     console.error(err)
-    return new NextResponse('Failed to fetch articulado', { status: 500 })
+    return NextResponse.json(
+      { error: 'Failed to fetch articulado' },
+      { status: 500 }
+    )
   }
 }
 

--- a/app/api/rfqs/[id]/upload/route.ts
+++ b/app/api/rfqs/[id]/upload/route.ts
@@ -3,24 +3,33 @@ import * as XLSX from 'xlsx'
 import { getDb } from '@/lib/db'
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
-  const formData = await req.formData()
-  const file = formData.get('file')
-  if (!file || !(file instanceof File)) {
-    return NextResponse.json({ error: 'File is required' }, { status: 400 })
+  try {
+    const formData = await req.formData()
+    const file = formData.get('file')
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json({ error: 'File is required' }, { status: 400 })
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+    const workbook = XLSX.read(buffer, { type: 'buffer' })
+    const sheet = workbook.SheetNames[0]
+    const rows = XLSX.utils.sheet_to_json(workbook.Sheets[sheet]) as any[]
+
+    const db = await getDb()
+    for (const row of rows) {
+      await db
+        .request()
+        .input('RFQId', params.id)
+        .input('Data', JSON.stringify(row))
+        .query('INSERT INTO SupplierResponses (RFQId, Data) VALUES (@RFQId, @Data)')
+    }
+
+    return NextResponse.json({ success: true, rows: rows.length })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json(
+      { error: 'Failed to upload responses' },
+      { status: 500 }
+    )
   }
-
-  const buffer = Buffer.from(await file.arrayBuffer())
-  const workbook = XLSX.read(buffer, { type: 'buffer' })
-  const sheet = workbook.SheetNames[0]
-  const rows = XLSX.utils.sheet_to_json(workbook.Sheets[sheet]) as any[]
-
-  const db = await getDb()
-  for (const row of rows) {
-    await db.request()
-      .input('RFQId', params.id)
-      .input('Data', JSON.stringify(row))
-      .query('INSERT INTO SupplierResponses (RFQId, Data) VALUES (@RFQId, @Data)')
-  }
-
-  return NextResponse.json({ success: true, rows: rows.length })
 }


### PR DESCRIPTION
## Summary
- handle errors for GET/POST rfqs API
- add error handling for rfq upload endpoint
- return JSON errors in articulado API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d66cd9f3083329a634248c1b7cc31